### PR TITLE
Add XDT Transform Visitor and command line interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ AppPackages/
 [Bb]in
 [Oo]bj
 sql
+sqlite3
 TestResults
 [Tt]est[Rr]esult*
 *.Cache

--- a/XmlDiff.Tests/XdtVisitorTests.cs
+++ b/XmlDiff.Tests/XdtVisitorTests.cs
@@ -1,0 +1,39 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using XmlDiff.Visitors;
+
+namespace XmlDiff.Tests
+{
+    [TestFixture]
+    class XdtVisitorTests
+    {
+        private XmlComparer _xmlDiff = new XmlComparer();
+
+        [Test]
+        public void Compare_SameDocument()
+        {
+            var sourceDoc = new XDocument(new XElement("configuration", 
+                new XElement("appSettings",
+                    new XElement("add", new XAttribute("key", "example"), new XAttribute("value", "foobar"))
+                )
+            ));
+            
+            DiffNode output = _xmlDiff.Compare(sourceDoc.Root, new XDocument(sourceDoc).Root);
+
+            var visitor = new XdtVisitor();
+            visitor.VisitWithDefaultSettings(output);
+            var result = XDocument.Parse(visitor.Result);
+
+            // document should have a root element with the same name as in the original document
+            Assert.AreEqual(result.Root.Name, sourceDoc.Root.Name);
+            // that root element should have the xdt prefix namespace
+            Assert.AreEqual(result.Root.GetPrefixOfNamespace(XdtVisitor._XdtNamespaceUri), "xdt");
+            // that root element should be empty, as there are no differences
+            Assert.IsFalse(result.Root.HasElements);
+        }
+    }
+}

--- a/XmlDiff.Tests/XdtVisitorTests.cs
+++ b/XmlDiff.Tests/XdtVisitorTests.cs
@@ -167,6 +167,21 @@ namespace XmlDiff.Tests
             Assert.AreEqual("SomeVal", result.Root.Element("appSettings").Elements().First().Value);
         }
 
+        [Test]
+        public void Xdt_TestSetAndRemoveAttributes() {
+            var destDoc = new XDocument(_simpleDoc);
+            destDoc.Root.Element("appSettings").Elements().First().SetAttributeValue("value", "baz");
+            destDoc.Root.Element("appSettings").Elements().First().Attributes("key").Remove();
+            DiffNode output = _xmlDiff.Compare(_simpleDoc.Root, destDoc.Root);
+
+            var visitor = new XdtVisitor();
+            visitor.Visit(output);
+            var result = XDocument.Parse(visitor.Result);
+            Assert.AreEqual(2, result.Root.Element("appSettings").Elements().Count());
+            Assert.AreEqual("SetAttributes(value)", _FindXdtAttribute(result.Root.Element("appSettings").Elements().First(), "Transform").Value);
+            Assert.AreEqual("RemoveAttributes(key)", _FindXdtAttribute(result.Root.Element("appSettings").Elements().Last(), "Transform").Value);
+        }
+
         private XAttribute _FindXdtAttribute(XElement element, string name = null)
         {
             var attrs = element.Attributes().Where(a => !a.IsNamespaceDeclaration).Where(a => a.Name.NamespaceName == XdtVisitor.XdtNamespaceUri);

--- a/XmlDiff.Tests/XdtVisitorTests.cs
+++ b/XmlDiff.Tests/XdtVisitorTests.cs
@@ -25,13 +25,13 @@ namespace XmlDiff.Tests
             DiffNode output = _xmlDiff.Compare(_simpleDoc.Root, new XDocument(_simpleDoc).Root);
 
             var visitor = new XdtVisitor();
-            visitor.VisitWithDefaultSettings(output);
+            visitor.Visit(output);
             var result = XDocument.Parse(visitor.Result);
 
             // document should have a root element with the same name as in the original document
             Assert.AreEqual(result.Root.Name, _simpleDoc.Root.Name);
             // that root element should have the xdt prefix namespace
-            Assert.AreEqual(result.Root.GetPrefixOfNamespace(XdtVisitor._XdtNamespaceUri), "xdt");
+            Assert.AreEqual(result.Root.GetPrefixOfNamespace(XdtVisitor.XdtNamespaceUri), "xdt");
             // that root element should be empty, as there are no differences
             Assert.IsFalse(result.Root.HasElements);
         }
@@ -46,7 +46,7 @@ namespace XmlDiff.Tests
             DiffNode output = _xmlDiff.Compare(_simpleDoc.Root, destDoc.Root);
 
             var visitor = new XdtVisitor();
-            visitor.VisitWithDefaultSettings(output);
+            visitor.Visit(output);
             var result = XDocument.Parse(visitor.Result);
 
             // root element should have no locator or transformation
@@ -79,7 +79,7 @@ namespace XmlDiff.Tests
             DiffNode output = _xmlDiff.Compare(_simpleDoc.Root, destDoc.Root);
 
             var visitor = new XdtVisitor();
-            visitor.VisitWithDefaultSettings(output);
+            visitor.Visit(output);
             var result = XDocument.Parse(visitor.Result);
 
             // there should be a Transform on the new element
@@ -98,7 +98,7 @@ namespace XmlDiff.Tests
             DiffNode output = _xmlDiff.Compare(_simpleDoc.Root, destDoc.Root);
 
             var visitor = new XdtVisitor();
-            visitor.VisitWithDefaultSettings(output);
+            visitor.Visit(output);
             var result = XDocument.Parse(visitor.Result);
 
             // root element should have no locator or transformation
@@ -122,7 +122,7 @@ namespace XmlDiff.Tests
             DiffNode output = _xmlDiff.Compare(sourceDoc.Root, destDoc.Root);
 
             var visitor = new XdtVisitor();
-            visitor.VisitWithDefaultSettings(output);
+            visitor.Visit(output);
             var result = XDocument.Parse(visitor.Result);
 
             // root element should have no locator or transformation
@@ -142,7 +142,7 @@ namespace XmlDiff.Tests
             DiffNode output = _xmlDiff.Compare(_simpleDoc.Root, destDoc.Root);
 
             var visitor = new XdtVisitor();
-            visitor.VisitWithDefaultSettings(output);
+            visitor.Visit(output);
             var result = XDocument.Parse(visitor.Result);
 
             // set and remove isn't possible in one go, so should be two instances with the same locator
@@ -153,9 +153,23 @@ namespace XmlDiff.Tests
             Assert.AreEqual(_FindXdtAttribute(second, "Transform").Value, "RemoveAttributes(value)");
         }
 
+        [Test]
+        public void Xdt_TestChangedValue() {
+            var destDoc = new XDocument(_simpleDoc);
+            destDoc.Root.Element("appSettings").Elements().First().Value = "SomeVal";
+            DiffNode output = _xmlDiff.Compare(_simpleDoc.Root, destDoc.Root);
+
+            var visitor = new XdtVisitor();
+            visitor.Visit(output);
+            var result = XDocument.Parse(visitor.Result);
+            Assert.AreEqual("Replace", _FindXdtAttribute(result.Root.Element("appSettings").Elements().First(), "Transform").Value);
+            Assert.AreEqual(1, result.Root.Element("appSettings").Elements().Count());
+            Assert.AreEqual("SomeVal", result.Root.Element("appSettings").Elements().First().Value);
+        }
+
         private XAttribute _FindXdtAttribute(XElement element, string name = null)
         {
-            var attrs = element.Attributes().Where(a => !a.IsNamespaceDeclaration).Where(a => a.Name.NamespaceName == XdtVisitor._XdtNamespaceUri);
+            var attrs = element.Attributes().Where(a => !a.IsNamespaceDeclaration).Where(a => a.Name.NamespaceName == XdtVisitor.XdtNamespaceUri);
             return attrs.FirstOrDefault(a => a.Name.LocalName == name || string.IsNullOrEmpty(name));
         }
     }

--- a/XmlDiff.Tests/XdtVisitorTests.cs
+++ b/XmlDiff.Tests/XdtVisitorTests.cs
@@ -86,11 +86,13 @@ namespace XmlDiff.Tests
         [Test]
         public void Xdt_TestNonUniqueElementNoUnchangedAttribute()
         {
-            var destDoc = new XDocument(_simpleDoc);
-            destDoc.Root.Element("appSettings").Elements().First().SetAttributeValue("value", "test value");
-            destDoc.Root.Element("appSettings").Elements().First().SetAttributeValue("key", "test_key");
+            var sourceDoc = new XDocument(_simpleDoc);
+            sourceDoc.Root.Element("appSettings").AddFirst(new XElement("test"));
+            var destDoc = new XDocument(sourceDoc);
+            destDoc.Root.Element("appSettings").Elements("add").First().SetAttributeValue("value", "test value");
+            destDoc.Root.Element("appSettings").Elements("add").First().SetAttributeValue("key", "test_key");
 
-            DiffNode output = _xmlDiff.Compare(_simpleDoc.Root, destDoc.Root);
+            DiffNode output = _xmlDiff.Compare(sourceDoc.Root, destDoc.Root);
 
             var visitor = new XdtVisitor();
             visitor.VisitWithDefaultSettings(output);
@@ -99,8 +101,8 @@ namespace XmlDiff.Tests
             // root element should have no locator or transformation
             Assert.IsNull(_FindXdtAttribute(result.Root));
             // changed element should be matched by a condition
-            Assert.AreEqual(_FindXdtAttribute(result.Root.Element("appSettings").Elements().First(), "Transform").Value, "SetAttributes(key,value)");
-            Assert.AreEqual(_FindXdtAttribute(result.Root.Element("appSettings").Elements().First(), "Locator").Value, "Condition([1])");
+            Assert.AreEqual(_FindXdtAttribute(result.Root.Element("appSettings").Elements("add").First(), "Transform").Value, "SetAttributes(key,value)");
+            Assert.AreEqual(_FindXdtAttribute(result.Root.Element("appSettings").Elements("add").First(), "Locator").Value, "Condition([1])");
         }
 
         [Test]

--- a/XmlDiff.Tests/XdtVisitorTests.cs
+++ b/XmlDiff.Tests/XdtVisitorTests.cs
@@ -12,28 +12,122 @@ namespace XmlDiff.Tests
     class XdtVisitorTests
     {
         private XmlComparer _xmlDiff = new XmlComparer();
-
-        [Test]
-        public void Compare_SameDocument()
-        {
-            var sourceDoc = new XDocument(new XElement("configuration", 
+        private XDocument _simpleDoc = new XDocument(new XElement("configuration",
                 new XElement("appSettings",
-                    new XElement("add", new XAttribute("key", "example"), new XAttribute("value", "foobar"))
+                    new XElement("add", new XAttribute("key", "example"), new XAttribute("value", "foobar")),
+                    new XElement("add", new XAttribute("key", "hello"), new XAttribute("value", "world"))
                 )
             ));
-            
-            DiffNode output = _xmlDiff.Compare(sourceDoc.Root, new XDocument(sourceDoc).Root);
+
+        [Test]
+        public void Xdt_SameDocument_ProducesBlankXdt()
+        {
+            DiffNode output = _xmlDiff.Compare(_simpleDoc.Root, new XDocument(_simpleDoc).Root);
 
             var visitor = new XdtVisitor();
             visitor.VisitWithDefaultSettings(output);
             var result = XDocument.Parse(visitor.Result);
 
             // document should have a root element with the same name as in the original document
-            Assert.AreEqual(result.Root.Name, sourceDoc.Root.Name);
+            Assert.AreEqual(result.Root.Name, _simpleDoc.Root.Name);
             // that root element should have the xdt prefix namespace
             Assert.AreEqual(result.Root.GetPrefixOfNamespace(XdtVisitor._XdtNamespaceUri), "xdt");
             // that root element should be empty, as there are no differences
             Assert.IsFalse(result.Root.HasElements);
+        }
+
+        [Test]
+        public void Xdt_ElementsHaveLocatorAndTransformWhenNeeded()
+        {
+            var destDoc = new XDocument(_simpleDoc);
+            destDoc.Root.Element("appSettings").Elements().First().SetAttributeValue("value", "test");
+            destDoc.Root.Element("appSettings").Add(new XElement("add", new XAttribute("key", "foo"), new XAttribute("value", "bar")));
+
+            DiffNode output = _xmlDiff.Compare(_simpleDoc.Root, destDoc.Root);
+
+            var visitor = new XdtVisitor();
+            visitor.VisitWithDefaultSettings(output);
+            var result = XDocument.Parse(visitor.Result);
+
+            // root element should have no locator or transformation
+            Assert.IsNull(_FindXdtAttribute(result.Root));
+            // same for appSettings
+            Assert.IsNull(_FindXdtAttribute(result.Root.Element("appSettings")));
+            // there should be two children - one updated, one inserted - the one that stays the same shouldn't appear in the transformation file
+            var children = result.Root.Element("appSettings").Elements();
+            Assert.AreEqual(children.Count(), 2);
+            // there should be a Locator and a Transform on the changed setting
+            Assert.AreEqual(_FindXdtAttribute(children.First(), "Locator").Value, "Match(key)");
+            Assert.AreEqual(_FindXdtAttribute(children.First(), "Transform").Value, "SetAttributes(value)");
+            // there should be a Transform on the new setting
+            Assert.AreEqual(_FindXdtAttribute(children.Last(), "Transform").Value, "Insert");
+            Assert.IsNull(_FindXdtAttribute(children.Last(), "Locator"));
+        }
+
+        [Test]
+        public void Xdt_TestRemoveUniqueElement()
+        {
+            var destDoc = new XDocument(_simpleDoc);
+            destDoc.Root.Element("appSettings").Remove();
+            
+            DiffNode output = _xmlDiff.Compare(_simpleDoc.Root, destDoc.Root);
+
+            var visitor = new XdtVisitor();
+            visitor.VisitWithDefaultSettings(output);
+            var result = XDocument.Parse(visitor.Result);
+
+            // root element should have no locator or transformation
+            Assert.IsNull(_FindXdtAttribute(result.Root));
+            // removed element should have a Transform but as it is unique, no Locator
+            Assert.AreEqual(_FindXdtAttribute(result.Root.Element("appSettings"), "Transform").Value, "Remove");
+            Assert.IsNull(_FindXdtAttribute(result.Root.Element("appSettings"), "Locator"));
+        }
+
+        [Test]
+        public void Xdt_TestNonUniqueElementNoUnchangedAttribute()
+        {
+            var destDoc = new XDocument(_simpleDoc);
+            destDoc.Root.Element("appSettings").Elements().First().SetAttributeValue("value", "test value");
+            destDoc.Root.Element("appSettings").Elements().First().SetAttributeValue("key", "test_key");
+
+            DiffNode output = _xmlDiff.Compare(_simpleDoc.Root, destDoc.Root);
+
+            var visitor = new XdtVisitor();
+            visitor.VisitWithDefaultSettings(output);
+            var result = XDocument.Parse(visitor.Result);
+
+            // root element should have no locator or transformation
+            Assert.IsNull(_FindXdtAttribute(result.Root));
+            // changed element should be matched by a condition
+            Assert.AreEqual(_FindXdtAttribute(result.Root.Element("appSettings").Elements().First(), "Transform").Value, "SetAttributes(key,value)");
+            Assert.AreEqual(_FindXdtAttribute(result.Root.Element("appSettings").Elements().First(), "Locator").Value, "Condition([1])");
+        }
+
+        [Test]
+        public void Xdt_TestRemoveAndSetAttribute()
+        {
+            var destDoc = new XDocument(_simpleDoc);
+            destDoc.Root.Element("appSettings").Elements().First().Attributes("value").Remove();
+            destDoc.Root.Element("appSettings").Elements().First().SetAttributeValue("key", "test_key");
+
+            DiffNode output = _xmlDiff.Compare(_simpleDoc.Root, destDoc.Root);
+
+            var visitor = new XdtVisitor();
+            visitor.VisitWithDefaultSettings(output);
+            var result = XDocument.Parse(visitor.Result);
+
+            // set and remove isn't possible in one go, so should be two instances with the same locator
+            Assert.AreEqual(_FindXdtAttribute(result.Root.Element("appSettings").Elements().First(), "Transform").Value, "SetAttributes(key)");
+            var second = result.Root.Element("appSettings").Elements().Skip(1).First();
+            Assert.AreEqual(result.Root.Element("appSettings").Elements().First().Name, second.Name);
+            Assert.AreEqual(_FindXdtAttribute(second, "Locator").Value, _FindXdtAttribute(result.Root.Element("appSettings").Elements().First(), "Locator").Value);
+            Assert.AreEqual(_FindXdtAttribute(second, "Transform").Value, "RemoveAttributes(value)");
+        }
+
+        private XAttribute _FindXdtAttribute(XElement element, string name = null)
+        {
+            var attrs = element.Attributes().Where(a => !a.IsNamespaceDeclaration).Where(a => a.Name.NamespaceName == XdtVisitor._XdtNamespaceUri);
+            return attrs.FirstOrDefault(a => a.Name.LocalName == name || string.IsNullOrEmpty(name));
         }
     }
 }

--- a/XmlDiff.Tests/XmlDiff.Tests.csproj
+++ b/XmlDiff.Tests/XmlDiff.Tests.csproj
@@ -47,6 +47,7 @@
     <Compile Include="DiffNodeTests.cs" />
     <Compile Include="DiffValueTests.cs" />
     <Compile Include="IndexedNameTests.cs" />
+    <Compile Include="XdtVisitorTests.cs" />
     <Compile Include="XmlDiffTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -58,6 +59,9 @@
       <Project>{F43EBA70-3C26-409C-BD58-2E87A4A8D009}</Project>
       <Name>XmlDiff</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/XmlDiff.sln
+++ b/XmlDiff.sln
@@ -1,9 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2010
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2010
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XmlDiff", "XmlDiff\XmlDiff.csproj", "{F43EBA70-3C26-409C-BD58-2E87A4A8D009}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XmlDiff.Tests", "XmlDiff.Tests\XmlDiff.Tests.csproj", "{BF7F39C1-E144-4590-8755-6883A3557B43}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XmlDifferConsole", "XmlDifferConsole\XmlDifferConsole.csproj", "{01A99209-5919-4202-87FA-F6E234812B9C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -35,8 +39,23 @@ Global
 		{BF7F39C1-E144-4590-8755-6883A3557B43}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{BF7F39C1-E144-4590-8755-6883A3557B43}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{BF7F39C1-E144-4590-8755-6883A3557B43}.Release|x86.ActiveCfg = Release|Any CPU
+		{01A99209-5919-4202-87FA-F6E234812B9C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01A99209-5919-4202-87FA-F6E234812B9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01A99209-5919-4202-87FA-F6E234812B9C}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{01A99209-5919-4202-87FA-F6E234812B9C}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{01A99209-5919-4202-87FA-F6E234812B9C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{01A99209-5919-4202-87FA-F6E234812B9C}.Debug|x86.Build.0 = Debug|Any CPU
+		{01A99209-5919-4202-87FA-F6E234812B9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01A99209-5919-4202-87FA-F6E234812B9C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{01A99209-5919-4202-87FA-F6E234812B9C}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{01A99209-5919-4202-87FA-F6E234812B9C}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{01A99209-5919-4202-87FA-F6E234812B9C}.Release|x86.ActiveCfg = Release|Any CPU
+		{01A99209-5919-4202-87FA-F6E234812B9C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1491C259-066C-429D-A845-688BA84AF052}
 	EndGlobalSection
 EndGlobal

--- a/XmlDiff/DiffAttribute.cs
+++ b/XmlDiff/DiffAttribute.cs
@@ -8,11 +8,8 @@ namespace XmlDiff
 	{
 		public DiffAttribute(DiffAction action, XAttribute raw)
 		{
-			if (raw == null)
-				throw new ArgumentNullException("raw");
-
 			Action = action;
-			Raw = raw;
+			Raw = raw ?? throw new ArgumentNullException(nameof(raw));
 		}
 
 		public DiffAction Action { get; private set; }

--- a/XmlDiff/DiffNode.cs
+++ b/XmlDiff/DiffNode.cs
@@ -16,10 +16,7 @@ namespace XmlDiff
 
 		public DiffNode(XElement raw, IEnumerable<DiffContent> content)
 		{
-			if (raw == null)
-				throw new ArgumentNullException("raw");
-
-			Raw = raw;
+			Raw = raw ?? throw new ArgumentNullException(nameof(raw));
 			Content = content ?? Enumerable.Empty<DiffContent>();
 		}
 

--- a/XmlDiff/DiffValue.cs
+++ b/XmlDiff/DiffValue.cs
@@ -8,7 +8,7 @@ namespace XmlDiff
 		public DiffValue(DiffAction action, string raw)
 		{
 			if (string.IsNullOrEmpty(raw))
-				throw new ArgumentNullException("raw");
+				throw new ArgumentNullException(nameof(raw));
 
 			Action = action;
 			Raw = raw;

--- a/XmlDiff/Visitors/HtmlVisitor.cs
+++ b/XmlDiff/Visitors/HtmlVisitor.cs
@@ -39,7 +39,7 @@ namespace XmlDiff.Visitors
 		public void Visit(DiffAttribute attr, int param)
 		{
 			_sb.AppendFormat("<span{0}>\"{1}\"=\"{2}\"</span>",
-				ActionToString(attr.Action), attr.Raw.Name, attr.Raw.Value);
+				ActionToString(attr.Action), attr.Raw.Name, System.Security.SecurityElement.Escape(attr.Raw.Value));
 		}
 
 		public void Visit(DiffValue val, int param)
@@ -51,7 +51,7 @@ namespace XmlDiff.Visitors
 				indent = BuildIndent(param);
 				_closeLineWithoutPrefixMode = true;
 			}
-			_sb.AppendFormat("{0}<span{1}>{2}</span>", indent, ActionToString(val.Action), val.Raw);
+			_sb.AppendFormat("{0}<span{1}>{2}</span>", indent, ActionToString(val.Action), System.Security.SecurityElement.Escape(val.Raw));
 		}
 
 		public void Visit(DiffNode node, int param)
@@ -60,17 +60,18 @@ namespace XmlDiff.Visitors
 
 			string indent = BuildIndent(param);
 			string action = ActionToString(node.DiffAction);
-			_sb.AppendFormat("{0}<span{1}>&lt{2}", indent, action, node.Raw.Name);
+			_sb.AppendFormat("{0}<span{1}>&lt;{2}", indent, action, node.Raw.Name);
 
 			if (node.DiffAction == null)
 			{
+				_sb.Append("</span>");
 				foreach (DiffContent content in node.Content)
 				{
 					content.Accept(this, param + 1);
 				}
 				DrawLineBreak();
 
-				string closingTag = string.Format("{0}<span{1}>&lt/{2}&gt", indent, action, node.Raw.Name);
+				string closingTag = string.Format("{0}<span{1}>&lt;/{2}&gt;</span>", indent, action, node.Raw.Name);
 				DrawLineBreak(openNew: param != 0, closingPrefix: closingTag);
 				_closeLineWithoutPrefixMode = true;
 
@@ -78,6 +79,7 @@ namespace XmlDiff.Visitors
 			{
 				AppendRawAttributesToSb(node, _sb);
 				_sb.Append("/");
+				_sb.Append("</span>");
 			}
 		}
 
@@ -87,7 +89,7 @@ namespace XmlDiff.Visitors
 			_sb.Append("</body>");
 		}
 
-		private void DrawLineBreak(bool openNew = true, string closingPrefix = "&gt")
+		private void DrawLineBreak(bool openNew = true, string closingPrefix = "&gt;")
 		{
 			if (_lineNumber > 0)
 			{
@@ -103,6 +105,7 @@ namespace XmlDiff.Visitors
 				_lineNumber++;
 			}
 
+			_sb.Append(Environment.NewLine);
 			_closeLineWithoutPrefixMode = false;
 		}
 
@@ -115,7 +118,7 @@ namespace XmlDiff.Visitors
 				while (enumerator.MoveNext() && left > 0)
 				{
 					XAttribute attr = enumerator.Current;
-					sb.AppendFormat("<span>\"{0}\"=\"{1}\"</span>", attr.Name, attr.Value);
+					sb.AppendFormat("<span>\"{0}\"=\"{1}\"</span>", attr.Name, System.Security.SecurityElement.Escape(attr.Value));
 					left--;
 				}
 				if (enumerator.MoveNext())
@@ -124,7 +127,7 @@ namespace XmlDiff.Visitors
 				}
 			} else
 			{
-				sb.Append("<span>...</span>");
+				//sb.Append("<span>...</span>");
 			}
 		}
 

--- a/XmlDiff/Visitors/HtmlVisitor.cs
+++ b/XmlDiff/Visitors/HtmlVisitor.cs
@@ -36,6 +36,8 @@ namespace XmlDiff.Visitors
 			get { return _sb.ToString(); }
 		}
 
+		public int Initial { get { return 0; } }
+
 		public void Visit(DiffAttribute attr, int param)
 		{
 			_sb.AppendFormat("<span{0}>\"{1}\"=\"{2}\"</span>",
@@ -83,9 +85,9 @@ namespace XmlDiff.Visitors
 			}
 		}
 
-		public void VisitWithDefaultSettings(DiffNode node)
+		public void Visit(DiffNode node)
 		{
-			Visit(node, 0);
+			Visit(node, Initial);
 			_sb.Append("</body>");
 		}
 

--- a/XmlDiff/Visitors/HtmlVisitor.cs
+++ b/XmlDiff/Visitors/HtmlVisitor.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Xml.Linq;
 
@@ -12,8 +13,8 @@ namespace XmlDiff.Visitors
 			get
 			{
 				return
-					string.Join(string.Empty,
-					"<style type=\"text/css\">",
+					string.Join(Environment.NewLine,
+					"<body><style type=\"text/css\">",
 					"span { margin:5px;}",
 					".removed { background-color : #ffe6e6; text-decoration:line-through; }",
 					".added { background-color : #e6ffe6; }",
@@ -83,6 +84,7 @@ namespace XmlDiff.Visitors
 		public void VisitWithDefaultSettings(DiffNode node)
 		{
 			Visit(node, 0);
+			_sb.Append("</body>");
 		}
 
 		private void DrawLineBreak(bool openNew = true, string closingPrefix = "&gt")

--- a/XmlDiff/Visitors/IDiffParamsVisitor.cs
+++ b/XmlDiff/Visitors/IDiffParamsVisitor.cs
@@ -7,5 +7,6 @@ namespace XmlDiff.Visitors
 		void Visit(DiffValue val, T param);
 		void Visit(DiffNode node, T param);
 		void VisitWithDefaultSettings(DiffNode node);
+		string Result { get; }
 	}
 }

--- a/XmlDiff/Visitors/IDiffParamsVisitor.cs
+++ b/XmlDiff/Visitors/IDiffParamsVisitor.cs
@@ -3,10 +3,11 @@ namespace XmlDiff.Visitors
 {
 	public interface IDiffParamsVisitor<T>
 	{
+		T Initial { get; }
 		void Visit(DiffAttribute attr, T param);
 		void Visit(DiffValue val, T param);
 		void Visit(DiffNode node, T param);
-		void VisitWithDefaultSettings(DiffNode node);
+		void Visit(DiffNode node);
 		string Result { get; }
 	}
 }

--- a/XmlDiff/Visitors/IDiffVisitor.cs
+++ b/XmlDiff/Visitors/IDiffVisitor.cs
@@ -6,5 +6,6 @@ namespace XmlDiff.Visitors
 		void Visit(DiffAttribute attr);
 		void Visit(DiffValue val);
 		void Visit(DiffNode node);
+		string Result { get; }
 	}
 }

--- a/XmlDiff/Visitors/ToStringVisitor.cs
+++ b/XmlDiff/Visitors/ToStringVisitor.cs
@@ -8,6 +8,7 @@ namespace XmlDiff.Visitors
 	{
 		protected readonly int MaxAttributesPreviewCount = 2;
 		private readonly StringBuilder _sb = new StringBuilder();
+		public int Initial { get { return 0; } }
 
 		public string Result
 		{
@@ -45,9 +46,9 @@ namespace XmlDiff.Visitors
 			}
 		}
 
-		public void VisitWithDefaultSettings(DiffNode node)
+		public void Visit(DiffNode node)
 		{
-			Visit(node, 0);
+			Visit(node, Initial);
 		}
 
 		private void AppendRawAttributesToSb(DiffNode node, StringBuilder sb)

--- a/XmlDiff/Visitors/ToStringVisitor.cs
+++ b/XmlDiff/Visitors/ToStringVisitor.cs
@@ -58,6 +58,10 @@ namespace XmlDiff.Visitors
 				{
 					sb.AppendFormat(" \"{0}\"=\"{1}\"", attr.Name, attr.Value);
 				}
+				if (node.Raw.Attributes().Count() > MaxAttributesPreviewCount)
+				{
+					sb.AppendFormat("...");
+				}
 			}
 		}
 
@@ -74,16 +78,15 @@ namespace XmlDiff.Visitors
 
 		private static string ActionToString(DiffAction? diffAction)
 		{
-			if (diffAction == DiffAction.Added)
+			switch (diffAction)
 			{
-				return "+";
+				case DiffAction.Added:
+					return "+";
+				case DiffAction.Removed:
+					return "-";
+				default:
+					return "=";
 			}
-			if (diffAction == DiffAction.Removed)
-			{
-				return "-";
-			}
-
-			return "=";
 		}
 	}
 }

--- a/XmlDiff/Visitors/XdtVisitor.cs
+++ b/XmlDiff/Visitors/XdtVisitor.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml.Linq;
+using System.Linq;
+using System.IO;
+//using System.Xml.XPath;
+
+namespace XmlDiff.Visitors
+{
+    class RemovedAttribute
+    {
+        public readonly XName Attribute;
+
+        public RemovedAttribute(XName name)
+        {
+            this.Attribute = name;
+        }
+    }
+
+    class SetAttribute
+    {
+        public readonly XName Attribute;
+
+        public SetAttribute(XName name)
+        {
+            this.Attribute = name;
+        }
+    }
+
+    class Utf8StringWriter : StringWriter
+    {
+        public Utf8StringWriter(StringBuilder builder) : base(builder) { }
+        public override Encoding Encoding { get { return Encoding.UTF8; } }
+    }
+
+    public class XdtVisitor : IDiffVisitor
+    {
+        private readonly XDocument _xdt;
+        private XElement _CurrentElement;
+        private const string _XdtNamespaceUri = "http://schemas.microsoft.com/XML-Document-Transform";
+
+        public XdtVisitor()
+        {
+            this._xdt = new XDocument();
+        }
+
+        public string Result
+        {
+            get
+            {
+
+                // https://stackoverflow.com/a/3871822/4473405
+                var builder = new StringBuilder();
+                using (var writer = new Utf8StringWriter(builder))
+                {
+                    this._xdt.Save(writer);
+                }
+                return builder.ToString();
+            }
+        }
+
+        public void Visit(DiffAttribute attr)
+        {
+            if (attr.Action == DiffAction.Added)
+            {
+                this._CurrentElement.Add(attr.Raw);
+                this._CurrentElement.AddAnnotation(new SetAttribute(attr.Raw.Name));
+            } else
+            {
+                this._CurrentElement.AddAnnotation(new RemovedAttribute(attr.Raw.Name));
+            }
+        }
+
+        public void Visit(DiffValue val)
+        {
+            this._CurrentElement.SetValue(val.Raw);
+        }
+
+        public void Visit(DiffNode node)
+        {
+            // if there are no changes to this element or anything below it, and we have written the root element, then we have nothing to do
+            if (!node.IsChanged && this._CurrentElement != null)
+                return;
+
+            XElement element = new XElement(node.Raw.Name);
+            if (this._CurrentElement == null)
+                this._xdt.Add(element);
+            else
+                this._CurrentElement.Add(element);
+            if (this._xdt.Root == element)
+            {
+                // add the XDT namespace declaration
+                element.Add(new XAttribute(XNamespace.Xmlns + "xdt", _XdtNamespaceUri));
+            }
+            var prev = this._CurrentElement;
+            this._CurrentElement = element;
+            try
+            {
+                switch (node.DiffAction)
+                {
+                    case DiffAction.Removed:
+                        element.SetAttributeValue(XName.Get("Transform", _XdtNamespaceUri), "Remove");
+                        break;
+                    case DiffAction.Added:
+                        foreach (var item in node.Raw.Attributes())
+                        {
+                            this._CurrentElement.Add(item);
+                        }
+                        this._CurrentElement.SetAttributeValue(XName.Get("Transform", _XdtNamespaceUri), "Insert");
+                        foreach (var item in node.Raw.Nodes())
+                            this._CurrentElement.Add(item);
+                        break;
+                    default:
+                        foreach (var item in node.Content)
+                        {
+                            item.Accept(this);
+                        }
+                        break;
+                }
+                var set = this._CurrentElement.Annotations(typeof(SetAttribute)).OfType<SetAttribute>().ToArray();
+                var remove = this._CurrentElement.Annotations(typeof(RemovedAttribute)).OfType<RemovedAttribute>().Where(a => !set.Any(s => s.Attribute == a.Attribute)).ToArray();
+
+                if (node.DiffAction != DiffAction.Added)
+                {
+                    // find an attribute whose name and value is the same in both documents
+                    var unchanged_attributes = node.Raw.Attributes().Where(a => !set.Any(s => s.Attribute == a.Name) && !remove.Any(s => s.Attribute == a.Name)).ToArray();
+                    // restrict that to unique entires
+                    var siblings_with_same_name = node.Raw.ElementsBeforeSelf().Concat(node.Raw.ElementsAfterSelf()).Where(e => e.Name == node.Raw.Name).ToArray();
+                    var unique_attributes = unchanged_attributes.Where(a => siblings_with_same_name.All(e => e.Attribute(a.Name)?.Value != a.Value));
+                    var unique_attribute = unchanged_attributes.FirstOrDefault();
+                    if (unique_attribute != null)
+                    {
+                        this._CurrentElement.Add(unique_attribute);
+                        this._CurrentElement.SetAttributeValue(XName.Get("Locator", _XdtNamespaceUri), "Match(" + unique_attribute.Name + ")");
+                    }
+                    else if (unchanged_attributes.Any() && siblings_with_same_name.Any())
+                    {
+                        // there is at least one other sibling element with the same name, so locate this element using an XPath Condition of the index
+                        this._CurrentElement.SetAttributeValue(XName.Get("Locator", _XdtNamespaceUri), "Condition([" + (node.Raw.NodesBeforeSelf().Count() + 1) + "])");
+                    } // otherwise, let the XDT transformer intelligently locate the correct element to transform
+                    if (set.Any())
+                        this._CurrentElement.SetAttributeValue(XName.Get("Transform", _XdtNamespaceUri), "SetAttributes(" + string.Join(",", set.Select(a => a.Attribute)) + ")");
+                    if (remove.Any())
+                    {
+                        if (set.Any())
+                        {
+                            var first = this._CurrentElement;
+                            // copy this element's name and xdt locator attribute, if present
+                            this._CurrentElement = new XElement(first.Name, first.Attribute(XName.Get("Locator", _XdtNamespaceUri)));
+                            first.AddAfterSelf(this._CurrentElement);
+                        }
+                        this._CurrentElement.SetAttributeValue(XName.Get("Transform", _XdtNamespaceUri), "RemoveAttributes(" + string.Join(",", remove.Select(a => a.Attribute)) + ")");
+                    }
+                }
+            }
+            finally
+            {
+                this._CurrentElement = prev;
+            }
+        }
+
+        public void VisitWithDefaultSettings(DiffNode node)
+        {
+            Visit(node);
+        }
+    }
+}

--- a/XmlDiff/Visitors/XdtVisitor.cs
+++ b/XmlDiff/Visitors/XdtVisitor.cs
@@ -113,9 +113,7 @@ namespace XmlDiff.Visitors {
 			if (!source.Attributes(XdtElement("Transform")).Any()) {
 				return source;
 			}
-			var copy = new XElement(source.Name, source.Attributes());
-			source.AddAfterSelf(copy);
-			return copy;
+			return new XElement(source.Name, source.Attributes());
 		}
 
 		private string GetLocator(DiffNode node, XdtContext context) {

--- a/XmlDiff/Visitors/XdtVisitor.cs
+++ b/XmlDiff/Visitors/XdtVisitor.cs
@@ -8,49 +8,38 @@ using System.Xml.Linq;
 namespace XmlDiff.Visitors {
 
 	public sealed class XdtContext {
-
-		private readonly HashSet<XName> _removedAttres = new HashSet<XName>();
-		private readonly HashSet<XName> _addedAttrs = new HashSet<XName>();
-
-		public XElement CurrentElement { get; private set; }
-
-		public IEnumerable<XName> RemoveAttrs {
-			get {
-				var remaining = new HashSet<XName>(_removedAttres);
-				remaining.ExceptWith(_addedAttrs);
-				return remaining;
-			}
-		}
-
-		public IEnumerable<XName> SetAttrs {
-			get { return _addedAttrs; }
-		}
-
-		public IEnumerable<XName> Affected {
-			get { return _addedAttrs.Concat(_removedAttres); }
-		}
+		public XElement XElement { get; private set; }
+		public HashSet<XName> SetAttrs { get; private set; }
+		public HashSet<XName> RemoveAttrs { get; private set; }
+		public bool AttributeChanged { get { return SetAttrs.Any() || RemoveAttrs.Any(); } }
+		public bool ValueChanged { get; set; }
 
 		public XdtContext(XElement element) {
-			CurrentElement = element;
+			XElement = element;
+			SetAttrs = new HashSet<XName>();
+			RemoveAttrs = new HashSet<XName>();
 		}
 
 		public void HandleAttr(XName attr, DiffAction diffAction) {
 			if (diffAction == DiffAction.Added) {
-				_addedAttrs.Add(attr);
-			}
-			if (!_addedAttrs.Contains(attr)) {
-				_removedAttres.Add(attr);
+				SetAttrs.Add(attr);
+			} else if (diffAction == DiffAction.Removed) {
+				RemoveAttrs.Add(attr);
 			}
 		}
 	}
 
 	public class XdtVisitor : IDiffParamsVisitor<XdtContext> {
 
-		public const string _XdtNamespaceUri = "http://schemas.microsoft.com/XML-Document-Transform";
+		public const string XdtNamespaceUri = "http://schemas.microsoft.com/XML-Document-Transform";
 		private readonly XDocument _xdt;
 
 		public XdtVisitor() {
 			_xdt = new XDocument();
+		}
+
+		public XdtContext Initial {
+			get { return new XdtContext(new XElement("Initial")); }
 		}
 
 		public void Visit(DiffAttribute attr, XdtContext param) {
@@ -58,92 +47,116 @@ namespace XmlDiff.Visitors {
 		}
 
 		public void Visit(DiffValue val, XdtContext param) {
-			param.CurrentElement.SetValue(val.Raw);
-			param.CurrentElement.SetAttributeValue(XdtElement("Transform"), "Replace");
+			param.XElement.SetValue(val.Raw);
+			param.ValueChanged = true;
 		}
 
 		public void Visit(DiffNode node, XdtContext param) {
 			if (!node.IsChanged)
 				return;
 
-			XdtContext context = YieldCurrentContext(node);
-			param.CurrentElement.Add(context.CurrentElement);
+			XElement element = node.DiffAction == DiffAction.Added
+				? new XElement(node.Raw)
+				: new XElement(node.Raw.Name, node.Raw.Attributes());
 
-			if (node.DiffAction != DiffAction.Added) {
-				string locator = GetLocator(node, context.Affected);
-				if (locator != null) {
-					context.CurrentElement.SetAttributeValue(XdtElement("Locator"), locator);
+			var context = new XdtContext(element);
+			if (node.DiffAction == null) {
+				foreach (DiffContent item in node.Content) {
+					item.Accept(this, context);
 				}
+			}
 
-				if (context.RemoveAttrs.Any()) {
-					context.CurrentElement.SetAttributeValue(XdtElement("Transform"), "RemoveAttributes(" + string.Join(",", context.RemoveAttrs) + ")");
-				}
-				if (context.SetAttrs.Any()) {
-					GetNodeToAddAttributes(context).SetAttributeValue(XdtElement("Transform"), "SetAttributes(" + string.Join(",", context.SetAttrs) + ")");
-				}
+			element.SetAttributeValue(XdtElement("Locator"), GetLocator(node, context));
+			XElement transformationContext = context.XElement;
+			foreach (string transformation in GetElementTransformations(node.DiffAction, context)) {
+				transformationContext = GetTransformationContext(transformationContext);
+				transformationContext.SetAttributeValue(XdtElement("Transform"), transformation);
+				param.XElement.Add(transformationContext);
 			}
 		}
 
-		private XElement GetNodeToAddAttributes(XdtContext newContent) {
-			if (newContent.RemoveAttrs.Any()) {
-				var copy = new XElement(newContent.CurrentElement.Name, newContent.CurrentElement.Attributes());
-				newContent.CurrentElement.AddAfterSelf(copy);
-				return copy;
+		private IEnumerable<string> GetElementTransformations(DiffAction? diffAction, XdtContext context) {
+			switch (diffAction) {
+				case DiffAction.Added:
+					yield return "Insert";
+					break;
+				case DiffAction.Removed:
+					yield return "Remove";
+					break;
+				default:
+					if (context.ValueChanged) {
+						yield return "Replace";
+						//just replace an element, no additional actions to perform
+						yield break;
+					}
+					if (context.AttributeChanged) {
+						if (context.SetAttrs.Any()) {
+							yield return "SetAttributes(" + string.Join(",", context.SetAttrs) + ")";
+						}
+						List<XName> uniqueRemoveAttrs = context.RemoveAttrs.Except(context.SetAttrs).ToList();
+						if (uniqueRemoveAttrs.Count > 0) {
+							yield return "RemoveAttributes(" + string.Join(",", uniqueRemoveAttrs) + ")";
+						}
+					} else {
+						// yield null as a transformation context
+						yield return null;
+					}
+					break;
 			}
-			return newContent.CurrentElement;
 		}
 
-		private string GetLocator(DiffNode node, IEnumerable<XName> affectedAttrs) {
+		private XElement GetTransformationContext(XElement source) {
+			//sometimes we need to apply more then a single transformation
+			//i.e. add some attribute and remove another at the single time
+			//possible solution is to copy current element and specify 
+			//an addtional transformation separetely
+			if (!source.Attributes(XdtElement("Transform")).Any()) {
+				return source;
+			}
+			var copy = new XElement(source.Name, source.Attributes());
+			source.AddAfterSelf(copy);
+			return copy;
+		}
+
+		private string GetLocator(DiffNode node, XdtContext context) {
 			// todo: let's use an indexed locator always?
 			// pros: less code/logic + it's hard to locate some changes <node attr="123"... to <node attr="newVal"...
 			// cons: transformation becomes hard to read?
-			XElement[] prevSiblingsWithSameName = node.Raw.ElementsBeforeSelf().Where(e => e.Name == node.Raw.Name).ToArray();
-			XElement[] nextSiblingsWithSameName = node.Raw.ElementsAfterSelf().Where(e => e.Name == node.Raw.Name).ToArray();
+			if (node.DiffAction == DiffAction.Added) {
+				return null;
+			}
+			XElement rawElement = node.Raw;
+			XElement[] prevSiblingsWithSameName = rawElement.ElementsBeforeSelf().Where(e => e.Name == rawElement.Name).ToArray();
+			XElement[] nextSiblingsWithSameName = rawElement.ElementsAfterSelf().Where(e => e.Name == rawElement.Name).ToArray();
 			XElement[] siblingsWithSameName = prevSiblingsWithSameName.Concat(nextSiblingsWithSameName).ToArray();
 			if (siblingsWithSameName.Length == 0) {
 				return null;
 			}
 
-			XName[] uniqueAttrNames = node.Raw.Attributes()
+			XName[] uniqueAttrNames = rawElement.Attributes()
 				.Where(a => siblingsWithSameName.All(e => e.Attribute(a.Name)?.Value != a.Value))
 				.Select(x => x.Name)
-				.Except(affectedAttrs).ToArray();
+				.Except(context.SetAttrs.Concat(context.RemoveAttrs)).ToArray();
 			return uniqueAttrNames.Length == 0
-					? "Condition([" + (prevSiblingsWithSameName.Length + 1) + "])"
-					: "Match(" + uniqueAttrNames[0] + ")";
-		}
-
-		private XdtContext YieldCurrentContext(DiffNode node) {
-			if (node.DiffAction == DiffAction.Added) {
-				var elem = new XElement(node.Raw);
-				elem.SetAttributeValue(XdtElement("Transform"), "Insert");
-				return new XdtContext(elem);
-			}
-
-			var newElement = new XElement(node.Raw.Name, node.Raw.Attributes());
-			var newContext = new XdtContext(newElement);
-			if (node.DiffAction == DiffAction.Removed) {
-				newElement.SetAttributeValue(XdtElement("Transform"), "Remove");
-			} else {
-				foreach (DiffContent item in node.Content) {
-					item.Accept(this, newContext);
-				}
-			}
-			return newContext;
+				? "Condition([" + (prevSiblingsWithSameName.Length + 1) + "])"
+				: "Match(" + uniqueAttrNames[0] + ")";
 		}
 
 		private static XName XdtElement(string name) {
-			return XName.Get(name, _XdtNamespaceUri);
+			return XName.Get(name, XdtNamespaceUri);
 		}
 
 		// refactor later
-		public void VisitWithDefaultSettings(DiffNode node) {
+		public void Visit(DiffNode node) {
 			// TODO: should we reset internal variables / state so that the same visitor instance can be used for multiple diffs?
-			// I think we need change interface
-			var initial = new XdtContext(new XElement("Temp"));
+			XdtContext initial = Initial;
 			Visit(node, initial);
-			XElement res = initial.CurrentElement.Nodes().OfType<XElement>().First();
-			res.Add(new XAttribute(XNamespace.Xmlns + "xdt", _XdtNamespaceUri));
+			XElement res = initial.XElement.Nodes().OfType<XElement>().FirstOrDefault();
+			if (res != null) {
+				res.Add(new XAttribute(XNamespace.Xmlns + "xdt", XdtNamespaceUri));
+			} else {
+				res = new XElement(node.Raw.Name, new XAttribute(XNamespace.Xmlns + "xdt", XdtNamespaceUri));
+			}
 			_xdt.Add(res);
 		}
 
@@ -160,7 +173,10 @@ namespace XmlDiff.Visitors {
 
 		private sealed class Utf8StringWriter : StringWriter {
 			public Utf8StringWriter(StringBuilder builder) : base(builder) { }
-			public override Encoding Encoding { get { return Encoding.UTF8; } }
+
+			public override Encoding Encoding {
+				get { return Encoding.UTF8; }
+			}
 		}
 	}
 }

--- a/XmlDiff/Visitors/XdtVisitor.cs
+++ b/XmlDiff/Visitors/XdtVisitor.cs
@@ -126,7 +126,9 @@ namespace XmlDiff.Visitors
                     // find an attribute whose name and value is the same in both documents
                     var unchanged_attributes = node.Raw.Attributes().Where(a => !set.Any(s => s.Attribute == a.Name) && !remove.Any(s => s.Attribute == a.Name)).ToArray();
                     // restrict that to unique entires
-                    var siblings_with_same_name = node.Raw.ElementsBeforeSelf().Concat(node.Raw.ElementsAfterSelf()).Where(e => e.Name == node.Raw.Name).ToArray();
+                    var prev_siblings_with_same_name = node.Raw.ElementsBeforeSelf().Where(e => e.Name == node.Raw.Name).ToArray();
+                    var next_siblings_with_same_name = node.Raw.ElementsAfterSelf().Where(e => e.Name == node.Raw.Name).ToArray();
+                    var siblings_with_same_name = prev_siblings_with_same_name.Concat(next_siblings_with_same_name);
                     var unique_attributes = unchanged_attributes.Where(a => siblings_with_same_name.All(e => e.Attribute(a.Name)?.Value != a.Value));
                     var unique_attribute = unchanged_attributes.FirstOrDefault();
                     if (unique_attribute != null)
@@ -137,7 +139,7 @@ namespace XmlDiff.Visitors
                     else if (/*unchanged_attributes.Any() &&*/ siblings_with_same_name.Any())
                     {
                         // there is at least one other sibling element with the same name, so locate this element using an XPath Condition of the index
-                        this._CurrentElement.SetAttributeValue(XName.Get("Locator", _XdtNamespaceUri), "Condition([" + (node.Raw.NodesBeforeSelf().Count() + 1) + "])");
+                        this._CurrentElement.SetAttributeValue(XName.Get("Locator", _XdtNamespaceUri), "Condition([" + (prev_siblings_with_same_name.Count() + 1) + "])");
                     } // otherwise, let the XDT transformer intelligently locate the correct element to transform
                     if (set.Any())
                         this._CurrentElement.SetAttributeValue(XName.Get("Transform", _XdtNamespaceUri), "SetAttributes(" + string.Join(",", set.Select(a => a.Attribute)) + ")");

--- a/XmlDiff/Visitors/XdtVisitor.cs
+++ b/XmlDiff/Visitors/XdtVisitor.cs
@@ -134,7 +134,7 @@ namespace XmlDiff.Visitors
                         this._CurrentElement.Add(unique_attribute);
                         this._CurrentElement.SetAttributeValue(XName.Get("Locator", _XdtNamespaceUri), "Match(" + unique_attribute.Name + ")");
                     }
-                    else if (unchanged_attributes.Any() && siblings_with_same_name.Any())
+                    else if (/*unchanged_attributes.Any() &&*/ siblings_with_same_name.Any())
                     {
                         // there is at least one other sibling element with the same name, so locate this element using an XPath Condition of the index
                         this._CurrentElement.SetAttributeValue(XName.Get("Locator", _XdtNamespaceUri), "Condition([" + (node.Raw.NodesBeforeSelf().Count() + 1) + "])");

--- a/XmlDiff/Visitors/XdtVisitor.cs
+++ b/XmlDiff/Visitors/XdtVisitor.cs
@@ -38,7 +38,7 @@ namespace XmlDiff.Visitors
     {
         private readonly XDocument _xdt;
         private XElement _CurrentElement;
-        private const string _XdtNamespaceUri = "http://schemas.microsoft.com/XML-Document-Transform";
+        public const string _XdtNamespaceUri = "http://schemas.microsoft.com/XML-Document-Transform";
 
         public XdtVisitor()
         {
@@ -162,6 +162,7 @@ namespace XmlDiff.Visitors
 
         public void VisitWithDefaultSettings(DiffNode node)
         {
+            // TODO: should we reset internal variables / state so that the same visitor instance can be used for multiple diffs?
             Visit(node);
         }
     }

--- a/XmlDiff/XmlComparer.cs
+++ b/XmlDiff/XmlComparer.cs
@@ -8,7 +8,7 @@ namespace XmlDiff
 	public class XmlComparer : IXmlComparer
 	{
 		/// <summary>
-		/// Compare <paramref name="resultElement"/> with a <paramref name="sourceElement"/> 
+		/// Compare <paramref name="resultElement"/> with a <paramref name="sourceElement"/>
 		/// Comparison is made only for XElement, XAttribute or XText elements
 		/// All other xml elements such as XComment, CDATA etc would be ignored
 		/// </summary>
@@ -22,11 +22,11 @@ namespace XmlDiff
 		{
 			if (sourceElement == null)
 			{
-				throw new ArgumentNullException("sourceElement");
+				throw new ArgumentNullException(nameof(sourceElement));
 			}
 			if (resultElement == null)
 			{
-				throw new ArgumentNullException("resultElement");
+				throw new ArgumentNullException(nameof(resultElement));
 			}
 			if (sourceElement.Name != resultElement.Name)
 			{

--- a/XmlDiff/XmlDiff.csproj
+++ b/XmlDiff/XmlDiff.csproj
@@ -45,6 +45,7 @@
     <Compile Include="DiffNode.cs" />
     <Compile Include="DiffValue.cs" />
     <Compile Include="EmptyNode.cs" />
+    <Compile Include="Visitors\XdtVisitor.cs" />
     <Compile Include="Visitors\HtmlVisitor.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/XmlDifferConsole/App.config
+++ b/XmlDifferConsole/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
+</configuration>

--- a/XmlDifferConsole/Program.cs
+++ b/XmlDifferConsole/Program.cs
@@ -77,7 +77,7 @@ namespace XmlDifferConsole
                 }
 
                 var visitor = new HtmlVisitor();
-                visitor.VisitWithDefaultSettings(diff);
+                visitor.Visit(diff);
 
                 if (opt.Verbose)
                     Console.WriteLine("Writing HTML output to \"{0}\"...", opt.OutputHtmlFile);
@@ -96,7 +96,7 @@ namespace XmlDifferConsole
                 }
 
                 var visitor = new XdtVisitor();
-                visitor.VisitWithDefaultSettings(diff);
+                visitor.Visit(diff);
 
                 if (opt.Verbose)
                     Console.WriteLine("Writing XDT output to \"{0}\"...", opt.OutputXdtFile);
@@ -112,7 +112,7 @@ namespace XmlDifferConsole
             if (opt.Verbose || (string.IsNullOrEmpty(opt.OutputHtmlFile) && string.IsNullOrEmpty(opt.OutputXdtFile)))
             {
                 var vistor = new ToStringVisitor();
-                vistor.VisitWithDefaultSettings(diff);
+                vistor.Visit(diff);
                 Console.WriteLine(vistor.Result);
             }
         }

--- a/XmlDifferConsole/Program.cs
+++ b/XmlDifferConsole/Program.cs
@@ -63,7 +63,9 @@ namespace XmlDifferConsole
 
             var comparer = new XmlComparer();
             var diff = comparer.Compare(leftDoc.Root, rightDoc.Root);
-            var isChanged = diff.IsChanged;
+            if (!diff.IsChanged && opt.Verbose) {
+                Console.WriteLine("No changes detected!");
+            }
 
             if (opt.Verbose)
                 Console.WriteLine("Compared in {0} ms.", stopwatch.ElapsedMilliseconds);

--- a/XmlDifferConsole/Program.cs
+++ b/XmlDifferConsole/Program.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Xml.Linq;
+using XmlDiff;
+using XmlDiff.Visitors;
+
+namespace XmlDifferConsole
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            try
+            {
+                if (args.Length == 0)
+                {
+                    Console.WriteLine("Usage: {0} leftFile rightFile [outputHtmlFile]", AppDomain.CurrentDomain.FriendlyName);
+                    return;
+                }
+
+                var leftFile = args[0];
+                var rightFile = args[1];
+                var outputHTMLFile = string.Empty;
+                if (args.Length > 2)
+                    outputHTMLFile = args[2];
+
+                var verbose = true;
+                XDocument leftDoc = null;
+                XDocument rightDoc = null;
+                if (verbose)
+                    Console.WriteLine("Loading \"{0}\"...", leftFile);
+                leftDoc = XDocument.Load(leftFile);
+                if (verbose)
+                    Console.WriteLine("Loading \"{0}\"...", rightFile);
+                rightDoc = XDocument.Load(rightFile);
+
+                var stopwatch = new Stopwatch();
+                if (verbose)
+                {
+                    Console.WriteLine("Comparing differences...");
+                    stopwatch.Start();
+                }
+
+                var comparer = new XmlComparer();
+                var diff = comparer.Compare(leftDoc.Root, rightDoc.Root);
+                var isChanged = diff.IsChanged;
+
+                if (verbose)
+                {
+                    stopwatch.Stop();
+                    Console.WriteLine("Compared in {0} ms.", stopwatch.ElapsedMilliseconds);
+                }
+
+                if (!string.IsNullOrEmpty(outputHTMLFile))
+                {
+                    if (verbose)
+                        Console.WriteLine("Creating HTML output...");
+
+                    var visitor = new HtmlVisitor();
+                    visitor.VisitWithDefaultSettings(diff);
+
+                    if (verbose)
+                        Console.WriteLine("Writing HTML output to \"{0}\"...", outputHTMLFile);
+                    File.WriteAllText(outputHTMLFile, visitor.Result);
+                    if (verbose)
+                        Console.WriteLine("HTML output file created.");
+                }
+
+                {
+                    var vistor = new ToStringVisitor();
+                    vistor.VisitWithDefaultSettings(diff);
+                    Console.WriteLine(vistor.Result);
+                }
+            }
+            finally
+            {
+                if (Debugger.IsAttached)
+                {
+                    Console.WriteLine("Press any key to continue...");
+                    Console.ReadKey();
+                }
+            }
+        }
+    }
+}

--- a/XmlDifferConsole/Program.cs
+++ b/XmlDifferConsole/Program.cs
@@ -48,22 +48,18 @@ namespace XmlDifferConsole
             if (opt.Verbose)
             {
                 Console.WriteLine("Loading \"{0}\"...", opt.LeftFile);
-                stopwatch.Start();
             }
             leftDoc = XDocument.Load(opt.LeftFile);
             if (opt.Verbose)
             {
-                Console.WriteLine("Loaded in {0} ms.", stopwatch.ElapsedMilliseconds);
                 Console.WriteLine("Loading \"{0}\"...", opt.RightFile);
-                stopwatch.Restart();
             }
             rightDoc = XDocument.Load(opt.RightFile);
             if (opt.Verbose)
             {
-                Console.WriteLine("Loaded in {0} ms.", stopwatch.ElapsedMilliseconds);
                 Console.WriteLine("Comparing differences...");
-                stopwatch.Restart();
             }
+            stopwatch.Start();
 
             var comparer = new XmlComparer();
             var diff = comparer.Compare(leftDoc.Root, rightDoc.Root);

--- a/XmlDifferConsole/Program.cs
+++ b/XmlDifferConsole/Program.cs
@@ -113,6 +113,7 @@ namespace XmlDifferConsole
 
             if (opt.Verbose)
                 Console.WriteLine("\nShowing text diff:");
+            if (opt.Verbose || (string.IsNullOrEmpty(opt.OutputHtmlFile) && string.IsNullOrEmpty(opt.OutputXdtFile)))
             {
                 var vistor = new ToStringVisitor();
                 vistor.VisitWithDefaultSettings(diff);

--- a/XmlDifferConsole/Program.cs
+++ b/XmlDifferConsole/Program.cs
@@ -72,6 +72,11 @@ namespace XmlDifferConsole
                     vistor.VisitWithDefaultSettings(diff);
                     Console.WriteLine(vistor.Result);
                 }
+                {
+                    var vistor = new XdtVisitor();
+                    vistor.VisitWithDefaultSettings(diff);
+                    Console.WriteLine(vistor.Result);
+                }
             }
             finally
             {

--- a/XmlDifferConsole/Properties/AssemblyInfo.cs
+++ b/XmlDifferConsole/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("XmlDifferConsole")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("XmlDiff")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("01a99209-5919-4202-87fa-f6e234812b9c")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/XmlDifferConsole/XmlDifferConsole.csproj
+++ b/XmlDifferConsole/XmlDifferConsole.csproj
@@ -35,6 +35,9 @@
     <StartupObject>XmlDifferConsole.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="clipr, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\clipr.1.6.0.1\lib\net35\clipr.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
@@ -51,6 +54,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\XmlDiff\XmlDiff.csproj">

--- a/XmlDifferConsole/XmlDifferConsole.csproj
+++ b/XmlDifferConsole/XmlDifferConsole.csproj
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{01A99209-5919-4202-87FA-F6E234812B9C}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>XmlDifferConsole</RootNamespace>
+    <AssemblyName>XmlDifferConsole</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject>XmlDifferConsole.Program</StartupObject>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\XmlDiff\XmlDiff.csproj">
+      <Project>{f43eba70-3c26-409c-bd58-2e87a4a8d009}</Project>
+      <Name>XmlDiff</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/XmlDifferConsole/packages.config
+++ b/XmlDifferConsole/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="clipr" version="1.6.0.1" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
Hi,

Thanks for this great library! I've added a command line interface project for easier consumption, and the ability to generate an [XML Document Transformation file](https://msdn.microsoft.com/en-us/library/dd465326%28v=vs.110%29.aspx?f=255&MSPPError=-2147217396), and thought I'd show you my changes in case you want to include them upstream.

My main use case is for comparing .NET configuration files from Production environments (i.e. not under my control) to those in the development environment. Using this tool allows me to ensure that I can keep the deployment steps (under source control) for my projects up to date without accidentally undoing any config changes made by others. ;)